### PR TITLE
node-openweathermap is now browserifiable

### DIFF
--- a/openweather.coffee
+++ b/openweather.coffee
@@ -63,6 +63,6 @@ getWeather = (opts, cb) ->
     res.on 'data', (data) -> buffer += data;
       
     res.on 'end', () ->
-      json = JSON.parse buffer 'utf8'
+      json = JSON.parse buffer
       json.list = [] if ! json.list?
       cb json

--- a/openweather.js
+++ b/openweather.js
@@ -105,7 +105,7 @@
       });
       return res.on('end', function() {
         var json;
-        json = JSON.parse(buffer('utf8'));
+        json = JSON.parse(buffer);
         if (json.list == null) {
           json.list = [];
         }


### PR DESCRIPTION
I made a few changes which made this module browserifiable.

I made it so that http.get uses port 80 and withCredentials set to false.

With credentials should be ignored when using in a node app. Port 80 I dropped in just because browserify uses window.location.port by default for port number for http.get and so when you're testing locally you maybe on some random port and not 80.

I switched concatting the data set from the api to a string instead of concatting using a buffer. I believe theres a bug in Browserifies Buffer. :(
